### PR TITLE
Define version using the correct package

### DIFF
--- a/pyrp3/__init__.py
+++ b/pyrp3/__init__.py
@@ -1,3 +1,3 @@
 import importlib_metadata
 
-__version__ = importlib_metadata.version("linien-server")  # noqa: F401
+__version__ = importlib_metadata.version("pyrp3")  # noqa: F401


### PR DESCRIPTION
Trying to install pyrp3 separately, without linien-server, I had to perform this change which seems reasonable to me anyhow.