### PR TITLE
Refactor bit manipulation and remove `myhdl` dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,6 @@ readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
     "cached_property>=1.5.2",
-    "myhdl>=0.11",
     "numpy>=1.21.5",
     "rpyc>=5.0,<6.0",
 ]


### PR DESCRIPTION
Hi, we are planning to use linien on our lab. Would like to propose some helpful updates for the `pyp3` package. 

This PR focuses on:
- replacing the few instances of `intbv` from `myhdl` with native Python bitwise operations;
- and removing the `myhdl` dependency from the project setup. 
 
Given that `intbv` is utilized sparingly within the code, continuing to include `myhdl` as a dependency seems unnecessary and could potentially bloat the package.

Kindly requesting a review of these changes to validate the improvements and ensure no unintended side effects have been introduced. Your insights and approval would be greatly appreciated.